### PR TITLE
Fix of the following issues:

### DIFF
--- a/editor/build.gradle
+++ b/editor/build.gradle
@@ -33,6 +33,10 @@ task run(dependsOn: classes, type: JavaExec) {
     standardInput = System.in
     workingDir = project.assetsDir
     ignoreExitValue = true
+    if (System.properties['os.name'].toLowerCase().contains('mac')) {
+        jvmArgs "-XstartOnFirstThread"
+        jvmArgs "-Djava.awt.headless=true"
+    }
 }
 
 task distEditor(type: Jar) {

--- a/editor/src/main/com/mbrlabs/mundus/Main.java
+++ b/editor/src/main/com/mbrlabs/mundus/Main.java
@@ -16,10 +16,9 @@
 
 package com.mbrlabs.mundus;
 
+import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
-
-import java.awt.*;
 
 /**
  * @author Marcus Brummer
@@ -30,24 +29,11 @@ public class Main {
     public static final String TITLE = "Mundus v0.0.8";
 
     public static void main (String[] arg) {
-        final Rectangle maximumWindowBounds = GraphicsEnvironment.getLocalGraphicsEnvironment().getMaximumWindowBounds();
-        int width = (int) maximumWindowBounds.getWidth();
-        int height = (int) maximumWindowBounds.getHeight();
-
         Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+        DisplayMode dm = Lwjgl3ApplicationConfiguration.getDisplayMode();
+        config.setWindowedMode(dm.width, dm.height-10);
         config.setTitle(TITLE);
-        config.setWindowedMode(width, (int) (height - height * .05));
         new Lwjgl3Application(new Editor(), config);
-
-//        LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
-//
-//        config.width = width;
-//        config.height = (int) (height - height * .05);
-//        config.backgroundFPS = 0;
-//        config.title = TITLE;
-//
-//        new LwjglApplication(new Editor(), config);
-
     }
 
 }


### PR DESCRIPTION
0) https://github.com/mbrlabs/Mundus/issues/4
1) https://github.com/mbrlabs/Mundus/issues/5
Now, there is no dependency on AWT -- only Libgdx and LWJGL3 is used to deal with dimensions.
Perfectly runs on MacOS as well.
Please note, the configuration of the window width and height can be change to any.
Tested on MacOS X with latest El Capitan + Windows 7 x64