### PR TITLE
Log util upgrade

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
@@ -50,6 +50,25 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
         this.tags = null;
         this.components = new Array<Component>(3);
     }
+    
+//    /**
+//     * Make copy with existing gameObject and new id
+//     * @param gameObject 
+//     */
+//    public GameObject(GameObject gameObject, int id) {
+//        super(id);
+//        this.sceneGraph = gameObject.sceneGraph;
+//        this.setParent(gameObject.parent);
+//        this.children = gameObject.children;
+//        
+//        //no transformation is copied ! -> Copy constructor in super classes ?
+//                
+//        this.name = (name == null) ? DEFAULT_NAME : name;
+//        this.name = this.name + "_copy";
+//        this.active = gameObject.active;
+//        this.tags = gameObject.tags;
+//        this.components = gameObject.getComponents();
+//    }
 
     /**
      * Calls the render() method for each component in this and all child nodes.
@@ -211,6 +230,11 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
         int result = (id ^ (id >>> 16));
         result = 31 * result + name.hashCode();
         return result;
+    }
+    
+    @Override
+    public String toString() {
+        return name;
     }
 
 }

--- a/editor/src/main/com/mbrlabs/mundus/Main.java
+++ b/editor/src/main/com/mbrlabs/mundus/Main.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.mbrlabs.mundus;
 
 import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3WindowAdapter;
+import com.mbrlabs.mundus.utils.Log;
 
 /**
  * @author Marcus Brummer
@@ -31,24 +31,26 @@ public class Main {
 
     public static WindowCloseListener closeListener = null;
 
-    public static void main (String[] arg) {
-
+    public static void main(String[] arg) {
+        //Start Log instance
+        Log.init();
         Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
         config.setTitle(TITLE);
+        Log.info("Starting [{}]", TITLE);
 
         // Set initial window size. See issue #11
         DisplayMode dm = Lwjgl3ApplicationConfiguration.getDisplayMode();
-        if(System.getProperties().getProperty("os.name").toLowerCase().contains("mac")) {
+        if (System.getProperties().getProperty("os.name").toLowerCase().contains("mac")) {
             config.setWindowedMode((int) (dm.width * 0.80f), (int) (dm.height * 0.80f));
         } else {
-            config.setWindowedMode((int) (dm.width*0.95f), (int) (dm.height*0.95f));
+            config.setWindowedMode((int) (dm.width * 0.95f), (int) (dm.height * 0.95f));
         }
         config.setWindowPosition(-1, -1);
 
         config.setWindowListener(new Lwjgl3WindowAdapter() {
             @Override
             public boolean closeRequested() {
-                if(closeListener != null) {
+                if (closeListener != null) {
                     closeListener.onCloseRequested();
                     return false;
                 }
@@ -56,9 +58,11 @@ public class Main {
             }
         });
         new Lwjgl3Application(new Editor(), config);
+        Log.info("Shutting down [{}]", TITLE);
     }
 
     public interface WindowCloseListener {
+
         boolean onCloseRequested();
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/core/Mundus.java
+++ b/editor/src/main/com/mbrlabs/mundus/core/Mundus.java
@@ -95,7 +95,6 @@ public class Mundus {
         }
 
         initStyle();
-        Log.init();
         initFontAwesome();
 
         shapeRenderer = new ShapeRenderer();
@@ -191,7 +190,7 @@ public class Mundus {
         for(Field f : fields) {
             if(ReflectionUtils.hasFieldAnnotation(f, Inject.class)) {
                 injectableFields.add(f);
-                //Log.debug("DI: found injectable field: " + f.getName());
+                //Log.debug("DI: found injectable field: {}", f.getName());
             }
         }
 

--- a/editor/src/main/com/mbrlabs/mundus/core/kryo/DescriptorConverter.java
+++ b/editor/src/main/com/mbrlabs/mundus/core/kryo/DescriptorConverter.java
@@ -245,7 +245,7 @@ public class DescriptorConverter {
         }
 
         if(model == null) {
-            Log.fatal("MModel for MModelInstance not found: " + descriptor.getModelID());
+            Log.fatal("MModel for MModelInstance not found: {}", descriptor.getModelID());
             return null;
         }
 

--- a/editor/src/main/com/mbrlabs/mundus/core/project/ProjectContext.java
+++ b/editor/src/main/com/mbrlabs/mundus/core/project/ProjectContext.java
@@ -80,7 +80,7 @@ public class ProjectContext implements Disposable {
 
     @Override
     public void dispose() {
-        Log.debug("Disposing project current " + path);
+        Log.debug("Disposing project current {}", path);
         for(MModel model : models) {
             model.getModel().dispose();
         }

--- a/editor/src/main/com/mbrlabs/mundus/core/project/ProjectManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/core/project/ProjectManager.java
@@ -190,7 +190,7 @@ public class ProjectManager implements Disposable {
         for(MTexture tex : context.textures) {
             tex.texture = TextureUtils.loadMipmapTexture(
                     Gdx.files.absolute(FilenameUtils.concat(context.path, tex.getPath())), true);
-            Log.debug("Loaded texture: " + tex.getPath());
+            Log.debug("Loaded texture: {}", tex.getPath());
         }
 
         // load g3db models
@@ -226,7 +226,7 @@ public class ProjectManager implements Disposable {
         // save scene in .mundus file
         kryoManager.saveScene(projectContext, projectContext.currScene);
 
-        Log.debug("Saving currentProject " + projectContext.name+ " [" + projectContext.path + "]");
+        Log.debug("Saving currentProject {}", projectContext.name+ " [" + projectContext.path + "]");
     }
 
     /**
@@ -367,7 +367,7 @@ public class ProjectManager implements Disposable {
                     modelComponent.getModelInstance().modelInstance.transform = go.getTransform();
                     modelComponent.setShader(shaders.entityShader);
                 } else {
-                    Log.fatal("model for modelInstance not found: " + modelComponent.getModelInstance().getModel().id);
+                    Log.fatal("model for modelInstance not found: {}", modelComponent.getModelInstance().getModel().id);
                 }
             } else if(c.getType() == Component.Type.TERRAIN) {
                 ((TerrainComponent)c).setShader(shaders.terrainShader);

--- a/editor/src/main/com/mbrlabs/mundus/tools/picker/BasePicker.java
+++ b/editor/src/main/com/mbrlabs/mundus/tools/picker/BasePicker.java
@@ -44,13 +44,13 @@ public abstract class BasePicker implements Disposable {
         try {
             fbo = new FrameBuffer(Pixmap.Format.RGBA8888, width, height, true);
         } catch (Exception e) {
-            Log.error("FBO dimensions 100%: " + e.getMessage());
+            Log.error("FBO dimensions 100%: {}", e.getMessage());
             width *= 0.9f;
             height *= 0.9f;
             try {
                 fbo = new FrameBuffer(Pixmap.Format.RGBA8888, width, height, true);
             } catch (Exception ee) {
-                Log.error("FBO dimensions 90%: " + e.getMessage());
+                Log.error("FBO dimensions 90%: {}", e.getMessage());
             }
         }
 

--- a/editor/src/main/com/mbrlabs/mundus/ui/modules/menu/SceneMenu.java
+++ b/editor/src/main/com/mbrlabs/mundus/ui/modules/menu/SceneMenu.java
@@ -31,6 +31,7 @@ import com.mbrlabs.mundus.core.project.ProjectManager;
 import com.mbrlabs.mundus.events.ProjectChangedEvent;
 import com.mbrlabs.mundus.events.SceneAddedEvent;
 import com.mbrlabs.mundus.ui.Ui;
+import com.mbrlabs.mundus.utils.Log;
 
 /**
  * @author Marcus Brummer
@@ -107,7 +108,9 @@ public class SceneMenu extends Menu implements
 
     @Override
     public void onSceneAdded(SceneAddedEvent sceneAddedEvent) {
-        buildMenuItem(sceneAddedEvent.getScene().getName());
+        String sceneName = sceneAddedEvent.getScene().getName();
+        buildMenuItem(sceneName);
+        Log.traceTag("SceneMenu", "New scene [{}] added.", sceneName);
     }
 
 }

--- a/editor/src/main/com/mbrlabs/mundus/utils/Log.java
+++ b/editor/src/main/com/mbrlabs/mundus/utils/Log.java
@@ -32,7 +32,7 @@ import java.util.Date;
  * {} will be replaced with parameter in left to right order.
  * 
  * @author Marcus Brummer, codenigma
- * @version 26-11-2015
+ * @version 23-09-2015
  */
 public class Log {
 
@@ -271,7 +271,7 @@ public class Log {
     }
 
     public final static void printHeadLine(int logLevel, String title) {
-        log(logLevel, "|                  > " + title + " <");
+        log(logLevel, "|                  > {} <", title);
     }
 
     public final static void printUpperSeperationLine(int logLevel) {

--- a/editor/src/main/com/mbrlabs/mundus/utils/Log.java
+++ b/editor/src/main/com/mbrlabs/mundus/utils/Log.java
@@ -36,13 +36,14 @@ import java.util.Date;
  */
 public class Log {
 
+    public static final int TRACE = 5;
     public static final int DEBUG = 4;
     public static final int INFO = 3;
     public static final int WARN = 2;
     public static final int ERROR = 1;
     public static final int FATAL = 0;
 
-    public static int LOG_LEVEL = DEBUG;
+    public static int LOG_LEVEL = TRACE;
 
     private static File logFile;
     private static PrintWriter logFileWriter;
@@ -95,6 +96,12 @@ public class Log {
         return logFile.getParent();
     }
 
+    public static void trace(String msg, Object... params) {
+        if (LOG_LEVEL >= DEBUG) {
+            msg = completeMsg(msg, params);
+            print("[Trace] " + msg);
+        }
+    }
     public static void debug(String msg, Object... params) {
         if (LOG_LEVEL >= DEBUG) {
             msg = completeMsg(msg, params);
@@ -131,6 +138,12 @@ public class Log {
     }
 
     //Log with tag
+    public static void traceTag(String tag, String msg, Object... params) {
+        if (LOG_LEVEL >= DEBUG) {
+            msg = completeMsg(msg, params);
+            print("[Trace][" + tag + "] " + msg);
+        }
+    }
     public static void debugTag(String tag, String msg, Object... params) {
         if (LOG_LEVEL >= DEBUG) {
             msg = completeMsg(msg, params);
@@ -203,11 +216,8 @@ public class Log {
     }
 
     private static String completeMsg(String msg, Object... params) {
-        String tmp = null;
-        for(Object p : params) {
-            tmp = ""+p;
-            msg = msg.replaceFirst("\\{\\}", tmp);
-        }
+        for(Object p : params)
+            msg = msg.replaceFirst("\\{\\}", String.valueOf(p));
         return msg;
     }
     
@@ -220,6 +230,9 @@ public class Log {
      */
     public static void log(int logLevel, String msg, Object... params) {
         switch (logLevel) {
+            case TRACE:
+                trace(msg, params);
+                break;
             case DEBUG:
                 debug(msg, params);
                 break;
@@ -250,6 +263,9 @@ public class Log {
      */
     public static void logTag(int logLevel, String tag, String msg, Object... params) {
         switch (logLevel) {
+            case TRACE:
+                traceTag(tag, msg, params);
+                break;
             case DEBUG:
                 debugTag(tag, msg, params);
                 break;

--- a/editor/src/main/com/mbrlabs/mundus/utils/Log.java
+++ b/editor/src/main/com/mbrlabs/mundus/utils/Log.java
@@ -97,7 +97,7 @@ public class Log {
     }
 
     public static void trace(String msg, Object... params) {
-        if (LOG_LEVEL >= DEBUG) {
+        if (LOG_LEVEL >= TRACE) {
             msg = completeMsg(msg, params);
             print("[Trace] " + msg);
         }
@@ -139,7 +139,7 @@ public class Log {
 
     //Log with tag
     public static void traceTag(String tag, String msg, Object... params) {
-        if (LOG_LEVEL >= DEBUG) {
+        if (LOG_LEVEL >= TRACE) {
             msg = completeMsg(msg, params);
             print("[Trace][" + tag + "] " + msg);
         }

--- a/editor/src/main/com/mbrlabs/mundus/utils/Log.java
+++ b/editor/src/main/com/mbrlabs/mundus/utils/Log.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.mbrlabs.mundus.utils;
 
 import com.badlogic.gdx.Gdx;
@@ -26,10 +25,17 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
- * @author Marcus Brummer
+ * Log messages with different log levels.
+ * To save performance during runtime, string concatination is only run
+ * if log level is present.
+ * Use for example: Log.log(Log.INFO, "Msg with param {} and param {}", "param1", "param2");
+ * {} will be replaced with parameter in left to right order.
+ * 
+ * @author Marcus Brummer, codenigma
  * @version 26-11-2015
  */
 public class Log {
+
     public static final int DEBUG = 4;
     public static final int INFO = 3;
     public static final int WARN = 2;
@@ -42,7 +48,7 @@ public class Log {
     private static PrintWriter logFileWriter;
     private static SimpleDateFormat msgDateFormat = new SimpleDateFormat("[HH:mm]");
 
-    public static void init () {
+    public static void init() {
         System.setErr(new ErrorStreamInterceptor(System.err));
         Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
             @Override
@@ -56,24 +62,25 @@ public class Log {
         prepareLogFile();
     }
 
-    public static void dispose () {
+    public static void dispose() {
         info("Exiting");
         logFileWriter.close();
     }
 
-    public static FileHandle getLogFile () {
+    public static FileHandle getLogFile() {
         return Gdx.files.absolute(logFile.getAbsolutePath());
     }
 
-    private static void prepareLogFile () {
+    private static void prepareLogFile() {
         File logDirectory = new File(Registry.LOGS_DIR);
         logDirectory.mkdir();
 
         SimpleDateFormat fileDateFormat = new SimpleDateFormat("yy-MM-dd");
         String fileName = fileDateFormat.format(new Date());
-
+        fileName = "mundus " + fileName + ".log";
+        
         try {
-            logFile = new File(logDirectory, "mundus " + fileName + ".log");
+            logFile = new File(logDirectory, fileName);
             logFile.createNewFile();
             logFileWriter = new PrintWriter(new FileWriter(logFile, true));
         } catch (IOException e) {
@@ -81,85 +88,197 @@ public class Log {
         }
 
         logFileWriter.println();
-        info("Started: " + fileName);
+        info("Logging activated. Log file [{}] created. ", fileName);
     }
 
-    public static String getLogStoragePath () {
+    public static String getLogStoragePath() {
         return logFile.getParent();
     }
 
-    public static void debug (String msg) {
-        if (LOG_LEVEL >= DEBUG) print("[Debug] " + msg);
+    public static void debug(String msg, Object... params) {
+        if (LOG_LEVEL >= DEBUG) {
+            msg = completeMsg(msg, params);
+            print("[Debug] " + msg);
+        }
     }
 
-    public static void info (String msg) {
-        if (LOG_LEVEL >= INFO) print("[Info] " + msg);
+    public static void info(String msg, Object... params) {
+        if (LOG_LEVEL >= INFO) {
+            msg = completeMsg(msg, params);
+            print("[Info] " + msg);
+        }
     }
 
-    public static void warn (String msg) {
-        if (LOG_LEVEL >= WARN) print("[Warning] " + msg);
+    public static void warn(String msg, Object... params) {
+        if (LOG_LEVEL >= WARN) {
+            msg = completeMsg(msg, params);
+            print("[Warning] " + msg);
+        }
     }
 
-    public static void error (String msg) {
-        if (LOG_LEVEL >= ERROR) printErr("[Error] " + msg);
+    public static void error(String msg, Object... params) {
+        if (LOG_LEVEL >= ERROR) {
+            msg = completeMsg(msg, params);
+            printErr("[Error] " + msg);
+        }
     }
 
-    public static void fatal (String msg) {
-        if (LOG_LEVEL >= FATAL) printErr("[Fatal] " + msg);
+    public static void fatal(String msg, Object... params) {
+        if (LOG_LEVEL >= FATAL) {
+            msg = completeMsg(msg, params);
+            printErr("[Fatal] " + msg);
+        }
     }
 
     //Log with tag
-
-    public static void debug (String tag, String msg) {
-        if (LOG_LEVEL >= DEBUG) print("[Debug][" + tag + "] " + msg);
+    public static void debugTag(String tag, String msg, Object... params) {
+        if (LOG_LEVEL >= DEBUG) {
+            msg = completeMsg(msg, params);
+            print("[Debug][" + tag + "] " + msg);
+        }
     }
 
-    public static void info (String tag, String msg) {
-        if (LOG_LEVEL >= INFO) print("[Info][" + tag + "] " + msg);
+    public static void infoTag(String tag, String msg, Object... params) {
+        if (LOG_LEVEL >= INFO) {
+            msg = completeMsg(msg, params);
+            print("[Info][" + tag + "] " + msg);
+        }
     }
 
-    public static void warn (String tag, String msg) {
-        if (LOG_LEVEL >= WARN) print("[Warning][" + tag + "] " + msg);
+    public static void warnTag(String tag, String msg, Object... params) {
+        if (LOG_LEVEL >= WARN) {
+            msg = completeMsg(msg, params);
+            print("[Warning][" + tag + "] " + msg);
+        }
     }
 
-    public static void error (String tag, String msg) {
-        if (LOG_LEVEL >= ERROR) printErr("[Error][" + tag + "] " + msg);
+    public static void errorTag(String tag, String msg, Object... params) {
+        if (LOG_LEVEL >= ERROR) {
+            msg = completeMsg(msg, params);
+            printErr("[Error][" + tag + "] " + msg);
+        }
     }
 
-    public static void fatal (String tag, String msg) {
-        if (LOG_LEVEL >= FATAL) printErr("[Fatal][" + tag + "] " + msg);
+    public static void fatalTag(String tag, String msg, Object... params) {
+        if (LOG_LEVEL >= FATAL) {
+            msg = completeMsg(msg, params);
+            printErr("[Fatal][" + tag + "] " + msg);
+        }
     }
 
-    private static void print (String msg) {
+    private static void print(String msg) {
         msg = getTimestamp() + msg;
         logFileWriter.println(msg);
         logFileWriter.flush();
         System.out.println(msg);
     }
 
-    private static void printErr (String msg) {
+    private static void printErr(String msg) {
         msg = getTimestamp() + msg;
         System.err.println(msg);
     }
 
-    public static void exception (Throwable e) {
+    public static void exception(Throwable e) {
         String stack = ExceptionUtils.getStackTrace(e);
         fatal(stack);
     }
 
-    private static String getTimestamp () {
+    private static String getTimestamp() {
         return msgDateFormat.format(new Date());
     }
 
     private static class ErrorStreamInterceptor extends PrintStream {
-        public ErrorStreamInterceptor (OutputStream out) {
+
+        public ErrorStreamInterceptor(OutputStream out) {
             super(out, true);
         }
 
         @Override
-        public void print (String s) {
+        public void print(String s) {
             super.print(s);
-            if (logFileWriter != null) logFileWriter.println(s);
+            if (logFileWriter != null) {
+                logFileWriter.println(s);
+            }
         }
+    }
+
+    private static String completeMsg(String msg, Object... params) {
+        String tmp = null;
+        for(Object p : params) {
+            tmp = ""+p;
+            msg = msg.replaceFirst("\\{\\}", tmp);
+        }
+        return msg;
+    }
+    
+    /**
+     * To save memory values will be concat to strings only when log level really is set
+     * Use {} in the msg as wild card
+     * @param logLevel
+     * @param msg
+     * @param params 
+     */
+    public static void log(int logLevel, String msg, Object... params) {
+        switch (logLevel) {
+            case DEBUG:
+                debug(msg, params);
+                break;
+            case INFO:
+                info(msg, params);
+                break;
+            case WARN:
+                warn(msg, params);
+                break;
+            case ERROR:
+                error(msg, params);
+                break;
+            case FATAL:
+                fatal(msg, params);
+                break;
+            default:
+                error("Log level " + logLevel + " is not supported!");
+        }
+    }
+
+    /**
+     * Log msg with tag
+     * To save memory values will be concat to strings only when log level really is set
+     * Use {} in the msg as wild card
+     * @param logLevel
+     * @param msg
+     * @param params 
+     */
+    public static void logTag(int logLevel, String tag, String msg, Object... params) {
+        switch (logLevel) {
+            case DEBUG:
+                debugTag(tag, msg, params);
+                break;
+            case INFO:
+                infoTag(tag, msg, params);
+                break;
+            case WARN:
+                warnTag(tag, msg, params);
+                break;
+            case ERROR:
+                errorTag(tag, msg, params);
+                break;
+            case FATAL:
+                fatalTag(tag, msg, params);
+                break;
+            default:
+                error("Log level " + logLevel + " is not supported!");
+        }
+    }
+
+    public final static void printHeadLine(int logLevel, String title) {
+        log(logLevel, "|                  > " + title + " <");
+    }
+
+    public final static void printUpperSeperationLine(int logLevel) {
+        log(logLevel, "↓‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾BEGIN‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾↓");
+    }
+
+    public final static void printLowerSeperationLine(int logLevel) {
+        log(logLevel, "↑_______________________END_______________________↑");
     }
 }

--- a/editor/src/main/com/mbrlabs/mundus/utils/TerrainIO.java
+++ b/editor/src/main/com/mbrlabs/mundus/utils/TerrainIO.java
@@ -97,7 +97,7 @@ public class TerrainIO {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        //Log.debug("Terrain import. floats: " + floatArray.size);
+        //Log.debug("Terrain import. floats: {}", floatArray.size);
 
         terrain.heightData = floatArray.toArray();
         terrain.init();


### PR DESCRIPTION
Upgraded Log util:
             1.
             Now with similiar behavior as log4j. 
             To save performance in logging, string concatination will be only run
             when log level is activated.
             Example: Log.debug("Some value {}", 4711)
             If log level is lower, "4711" will not be concatinated with msg string.
             2.
             Added delimiter method in logger to visually seperate code blocks:
             |              >Some header title<
             ↓‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾BEGIN‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾↓
             //more logs here
             ↑_______________________END_______________________↑
             3.
             Updated log messages to new syntax.