### PR TITLE
Duplicate Game Object, Issue #15

### DIFF
--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.mbrlabs.mundus.commons.scene3d;
 
 import com.badlogic.gdx.utils.Array;
@@ -38,9 +37,9 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
     public final SceneGraph sceneGraph;
 
     /**
-     * @param sceneGraph    scene graph
-     * @param name          game object name; can be null
-     * @param id            game object id
+     * @param sceneGraph scene graph
+     * @param name game object name; can be null
+     * @param id game object id
      */
     public GameObject(SceneGraph sceneGraph, String name, int id) {
         super(id);
@@ -50,33 +49,38 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
         this.tags = null;
         this.components = new Array<Component>(3);
     }
-    
-//    /**
-//     * Make copy with existing gameObject and new id
-//     * @param gameObject 
-//     */
-//    public GameObject(GameObject gameObject, int id) {
-//        super(id);
-//        this.sceneGraph = gameObject.sceneGraph;
-//        this.setParent(gameObject.parent);
-//        this.children = gameObject.children;
-//        
-//        //no transformation is copied ! -> Copy constructor in super classes ?
-//                
-//        this.name = (name == null) ? DEFAULT_NAME : name;
-//        this.name = this.name + "_copy";
-//        this.active = gameObject.active;
-//        this.tags = gameObject.tags;
-//        this.components = gameObject.getComponents();
-//    }
+
+    /**
+     * Make copy with existing gameObject and new id
+     *
+     * @param gameObject
+     */
+    public GameObject(GameObject gameObject, int id) {
+        super(gameObject, id); //call copy constructor of base class
+        this.sceneGraph = gameObject.sceneGraph;
+        //set name _copy  
+        this.name = gameObject.name + "_copy";
+        this.active = gameObject.active;
+        //deep copy tags
+        if (tags != null) {
+            Array<String> newTags = new Array<String>();
+            for (String t : gameObject.tags) {
+                newTags.add(t);
+            }
+            this.tags = newTags;
+        }
+        //ref components
+        this.components = gameObject.components;
+        this.setParent(gameObject.parent);
+    }
 
     /**
      * Calls the render() method for each component in this and all child nodes.
      *
-     * @param delta     time since last render
+     * @param delta time since last render
      */
     public void render(float delta) {
-        if(active) {
+        if (active) {
             for (Component component : this.components) {
                 component.render(delta);
             }
@@ -92,10 +96,10 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
     /**
      * Calls the update() method for each component in this and all child nodes.
      *
-     * @param delta     time since last update
+     * @param delta time since last update
      */
     public void update(float delta) {
-        if(active) {
+        if (active) {
             for (Component component : this.components) {
                 component.update(delta);
             }
@@ -110,7 +114,8 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
 
     /**
      * Returns the tags
-     * @return  tags or null if none available
+     *
+     * @return tags or null if none available
      */
     public Array<String> getTags() {
         return this.tags;
@@ -118,10 +123,11 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
 
     /**
      * Adds a tag.
+     *
      * @param tag tag to add
      */
     public void addTag(String tag) {
-        if(this.tags == null) {
+        if (this.tags == null) {
             this.tags = new Array<String>(2);
         }
 
@@ -131,21 +137,25 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
     /**
      * Finds all component by a given type.
      *
-     * @param out           output array
-     * @param type          component type
+     * @param out output array
+     * @param type component type
      * @param includeChilds search in node children of this game object as well?
-     * @return              components found
+     * @return components found
      */
     public Array<Component> findComponentsByType(Array<Component> out, Component.Type type, boolean includeChilds) {
-        if(includeChilds) {
-            for(GameObject go : this) {
-                for(Component c : go.components) {
-                    if(c.getType() == type) out.add(c);
+        if (includeChilds) {
+            for (GameObject go : this) {
+                for (Component c : go.components) {
+                    if (c.getType() == type) {
+                        out.add(c);
+                    }
                 }
             }
         } else {
-            for(Component c : components) {
-                if(c.getType() == type) out.add(c);
+            for (Component c : components) {
+                if (c.getType() == type) {
+                    out.add(c);
+                }
             }
         }
 
@@ -155,12 +165,14 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
     /**
      * Finds one component by type.
      *
-     * @param type  component type
-     * @return      component if found or null
+     * @param type component type
+     * @return component if found or null
      */
     public Component findComponentByType(Component.Type type) {
-        for(Component c : components) {
-            if(c.getType() == type) return c;
+        for (Component c : components) {
+            if (c.getType() == type) {
+                return c;
+            }
         }
 
         return null;
@@ -168,7 +180,8 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
 
     /**
      * Returns all components of this go.
-     * @return  components
+     *
+     * @return components
      */
     public Array<Component> getComponents() {
         return this.components;
@@ -176,6 +189,7 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
 
     /**
      * Removes a component.
+     *
      * @param component component to remove
      */
     public void removeComponent(Component component) {
@@ -200,8 +214,8 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
      */
     public void isComponentAddable(Component component) throws InvalidComponentException {
         // check for component of the same type
-        for(Component c : components) {
-            if(c.getType() == component.getType()) {
+        for (Component c : components) {
+            if (c.getType() == component.getType()) {
                 throw new InvalidComponentException("One Game object can't have more then 1 component of type " + c.getType());
             }
         }
@@ -214,13 +228,21 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         GameObject that = (GameObject) o;
 
-        if (id != that.id) return false;
-        if (!name.equals(that.name)) return false;
+        if (id != that.id) {
+            return false;
+        }
+        if (!name.equals(that.name)) {
+            return false;
+        }
 
         return true;
     }
@@ -231,7 +253,7 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
         result = 31 * result + name.hashCode();
         return result;
     }
-    
+
     @Override
     public String toString() {
         return name;

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/GameObject.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.mbrlabs.mundus.commons.scene3d;
 
 import com.badlogic.gdx.utils.Array;
@@ -37,9 +38,9 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
     public final SceneGraph sceneGraph;
 
     /**
-     * @param sceneGraph scene graph
-     * @param name game object name; can be null
-     * @param id game object id
+     * @param sceneGraph    scene graph
+     * @param name          game object name; can be null
+     * @param id            game object id
      */
     public GameObject(SceneGraph sceneGraph, String name, int id) {
         super(id);
@@ -49,11 +50,11 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
         this.tags = null;
         this.components = new Array<Component>(3);
     }
-
-    /**
+    
+/**
      * Make copy with existing gameObject and new id
      *
-     * @param gameObject
+     * @param gameObject    game object for clone
      */
     public GameObject(GameObject gameObject, int id) {
         super(gameObject, id); //call copy constructor of base class
@@ -74,13 +75,14 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
         this.setParent(gameObject.parent);
     }
 
+
     /**
      * Calls the render() method for each component in this and all child nodes.
      *
-     * @param delta time since last render
+     * @param delta     time since last render
      */
     public void render(float delta) {
-        if (active) {
+        if(active) {
             for (Component component : this.components) {
                 component.render(delta);
             }
@@ -96,10 +98,10 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
     /**
      * Calls the update() method for each component in this and all child nodes.
      *
-     * @param delta time since last update
+     * @param delta     time since last update
      */
     public void update(float delta) {
-        if (active) {
+        if(active) {
             for (Component component : this.components) {
                 component.update(delta);
             }
@@ -114,8 +116,7 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
 
     /**
      * Returns the tags
-     *
-     * @return tags or null if none available
+     * @return  tags or null if none available
      */
     public Array<String> getTags() {
         return this.tags;
@@ -123,11 +124,10 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
 
     /**
      * Adds a tag.
-     *
      * @param tag tag to add
      */
     public void addTag(String tag) {
-        if (this.tags == null) {
+        if(this.tags == null) {
             this.tags = new Array<String>(2);
         }
 
@@ -137,25 +137,21 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
     /**
      * Finds all component by a given type.
      *
-     * @param out output array
-     * @param type component type
+     * @param out           output array
+     * @param type          component type
      * @param includeChilds search in node children of this game object as well?
-     * @return components found
+     * @return              components found
      */
     public Array<Component> findComponentsByType(Array<Component> out, Component.Type type, boolean includeChilds) {
-        if (includeChilds) {
-            for (GameObject go : this) {
-                for (Component c : go.components) {
-                    if (c.getType() == type) {
-                        out.add(c);
-                    }
+        if(includeChilds) {
+            for(GameObject go : this) {
+                for(Component c : go.components) {
+                    if(c.getType() == type) out.add(c);
                 }
             }
         } else {
-            for (Component c : components) {
-                if (c.getType() == type) {
-                    out.add(c);
-                }
+            for(Component c : components) {
+                if(c.getType() == type) out.add(c);
             }
         }
 
@@ -165,14 +161,12 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
     /**
      * Finds one component by type.
      *
-     * @param type component type
-     * @return component if found or null
+     * @param type  component type
+     * @return      component if found or null
      */
     public Component findComponentByType(Component.Type type) {
-        for (Component c : components) {
-            if (c.getType() == type) {
-                return c;
-            }
+        for(Component c : components) {
+            if(c.getType() == type) return c;
         }
 
         return null;
@@ -180,8 +174,7 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
 
     /**
      * Returns all components of this go.
-     *
-     * @return components
+     * @return  components
      */
     public Array<Component> getComponents() {
         return this.components;
@@ -189,7 +182,6 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
 
     /**
      * Removes a component.
-     *
      * @param component component to remove
      */
     public void removeComponent(Component component) {
@@ -214,8 +206,8 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
      */
     public void isComponentAddable(Component component) throws InvalidComponentException {
         // check for component of the same type
-        for (Component c : components) {
-            if (c.getType() == component.getType()) {
+        for(Component c : components) {
+            if(c.getType() == component.getType()) {
                 throw new InvalidComponentException("One Game object can't have more then 1 component of type " + c.getType());
             }
         }
@@ -228,21 +220,13 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         GameObject that = (GameObject) o;
 
-        if (id != that.id) {
-            return false;
-        }
-        if (!name.equals(that.name)) {
-            return false;
-        }
+        if (id != that.id) return false;
+        if (!name.equals(that.name)) return false;
 
         return true;
     }
@@ -253,7 +237,7 @@ public class GameObject extends SimpleNode<GameObject> implements Iterable<GameO
         result = 31 * result + name.hashCode();
         return result;
     }
-
+    
     @Override
     public String toString() {
         return name;

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SimpleNode.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/SimpleNode.java
@@ -19,7 +19,6 @@ package com.mbrlabs.mundus.commons.scene3d;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Quaternion;
 import com.badlogic.gdx.math.Vector3;
-import com.badlogic.gdx.utils.Array;
 
 /**
  * Very simple and incredible inefficient implementation of a scene graph node.
@@ -50,7 +49,20 @@ public class SimpleNode<T extends SimpleNode> extends BaseNode<T> {
         localScale = new Vector3(1, 1, 1);
         combined = new Matrix4();
     }
-
+    
+    /**
+     * Copy construction
+     * @param simpleNode
+     * @param id 
+     */
+    public SimpleNode(SimpleNode simpleNode, int id) {
+        super(id);
+        this.localPosition = new Vector3(simpleNode.localPosition);
+        this.localRotation = new Quaternion(simpleNode.localRotation);
+        this.localScale = new Vector3(simpleNode.localScale);
+        this.combined = new Matrix4(simpleNode.combined);
+    }
+    
     @Override
     public Vector3 getLocalPosition(Vector3 out) {
         return out.set(localPosition);

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/Component.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/Component.java
@@ -35,5 +35,5 @@ public interface Component {
     public Type getType();
     public void setType(Type type);
     public void remove();
-    public Component deepCopy(GameObject go);
+    public Component clone(GameObject go);
 }

--- a/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/Component.java
+++ b/commons/src/main/com/mbrlabs/mundus/commons/scene3d/components/Component.java
@@ -35,5 +35,5 @@ public interface Component {
     public Type getType();
     public void setType(Type type);
     public void remove();
-
+    public Component deepCopy(GameObject go);
 }

--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -9,6 +9,7 @@
 - Improved logging
 - Fixed expanding of the game object tree in the outline if the scene graph has been modified (https://github.com/mbrlabs/Mundus/issues/8)
 - Implemented game object renaming in the outline
+- Implemented duplicate game object (deep copy), terrain can not be duplicated
 
 [0.0.8] ~ 23/06/2016
 - Updated libGDX to 1.9.3

--- a/editor/src/main/com/mbrlabs/mundus/scene3d/components/ModelComponent.java
+++ b/editor/src/main/com/mbrlabs/mundus/scene3d/components/ModelComponent.java
@@ -19,6 +19,7 @@ package com.mbrlabs.mundus.scene3d.components;
 import com.badlogic.gdx.graphics.g3d.Shader;
 import com.mbrlabs.mundus.commons.model.MModelInstance;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
+import com.mbrlabs.mundus.commons.scene3d.components.Component;
 import com.mbrlabs.mundus.shader.Shaders;
 import com.mbrlabs.mundus.tools.picker.PickerColorEncoder;
 import com.mbrlabs.mundus.tools.picker.PickerIDAttribute;
@@ -76,6 +77,14 @@ public class ModelComponent extends PickableComponent {
     @Override
     public void update(float delta) {
 
+    }
+
+    @Override
+    public Component deepCopy(GameObject go) {
+        ModelComponent mc = new ModelComponent(go);
+        mc.shader = this.shader;
+        mc.modelInstance = this.modelInstance;
+        return mc;
     }
 
 }

--- a/editor/src/main/com/mbrlabs/mundus/scene3d/components/ModelComponent.java
+++ b/editor/src/main/com/mbrlabs/mundus/scene3d/components/ModelComponent.java
@@ -80,11 +80,10 @@ public class ModelComponent extends PickableComponent {
     }
 
     @Override
-    public Component deepCopy(GameObject go) {
+    public Component clone(GameObject go) {
         ModelComponent mc = new ModelComponent(go);
         mc.shader = this.shader;
         mc.modelInstance = this.modelInstance;
         return mc;
     }
-
 }

--- a/editor/src/main/com/mbrlabs/mundus/scene3d/components/TerrainComponent.java
+++ b/editor/src/main/com/mbrlabs/mundus/scene3d/components/TerrainComponent.java
@@ -18,10 +18,12 @@ package com.mbrlabs.mundus.scene3d.components;
 
 import com.badlogic.gdx.graphics.g3d.Shader;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
+import com.mbrlabs.mundus.commons.scene3d.components.Component;
 import com.mbrlabs.mundus.commons.terrain.Terrain;
 import com.mbrlabs.mundus.shader.Shaders;
 import com.mbrlabs.mundus.tools.picker.PickerColorEncoder;
 import com.mbrlabs.mundus.tools.picker.PickerIDAttribute;
+import org.apache.commons.lang3.NotImplementedException;
 
 /**
  * @author Marcus Brummer
@@ -72,6 +74,11 @@ public class TerrainComponent extends PickableComponent {
     @Override
     public void update(float delta) {
 
+    }
+
+    @Override
+    public Component deepCopy(GameObject go) {
+        throw new NotImplementedException("Terrain can not be copied.");
     }
 
 }

--- a/editor/src/main/com/mbrlabs/mundus/scene3d/components/TerrainComponent.java
+++ b/editor/src/main/com/mbrlabs/mundus/scene3d/components/TerrainComponent.java
@@ -23,7 +23,7 @@ import com.mbrlabs.mundus.commons.terrain.Terrain;
 import com.mbrlabs.mundus.shader.Shaders;
 import com.mbrlabs.mundus.tools.picker.PickerColorEncoder;
 import com.mbrlabs.mundus.tools.picker.PickerIDAttribute;
-import org.apache.commons.lang3.NotImplementedException;
+import com.mbrlabs.mundus.utils.Log;
 
 /**
  * @author Marcus Brummer
@@ -77,8 +77,9 @@ public class TerrainComponent extends PickableComponent {
     }
 
     @Override
-    public Component deepCopy(GameObject go) {
-        throw new NotImplementedException("Terrain can not be copied.");
+    public Component clone(GameObject go) {
+        Log.fatalTag("TerrainComponent", "Terrain can not be cloned!");
+        return null;
     }
 
 }

--- a/editor/src/main/com/mbrlabs/mundus/ui/modules/Outline.java
+++ b/editor/src/main/com/mbrlabs/mundus/ui/modules/Outline.java
@@ -17,6 +17,7 @@ package com.mbrlabs.mundus.ui.modules;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
+import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
@@ -27,6 +28,9 @@ import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.scenes.scene2d.utils.DragAndDrop;
 import com.badlogic.gdx.scenes.scene2d.utils.Selection;
 import com.badlogic.gdx.utils.Align;
+import com.kotcrab.vis.ui.util.dialog.Dialogs;
+import com.kotcrab.vis.ui.util.dialog.Dialogs.InputDialog;
+import com.kotcrab.vis.ui.util.dialog.InputDialogAdapter;
 import com.kotcrab.vis.ui.widget.*;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.SceneGraph;
@@ -46,8 +50,10 @@ import com.mbrlabs.mundus.utils.Log;
 import com.mbrlabs.mundus.utils.TerrainUtils;
 
 /**
- * @author Marcus Brummer
- * @version 30-11-2015
+ * Outline shows overview about all game objects in the scene
+ *
+ * @author Marcus Brummer, codenigma
+ * @version 25-09-2016
  */
 public class Outline extends VisTable implements
         ProjectChangedEvent.ProjectChangedListener,
@@ -74,7 +80,7 @@ public class Outline extends VisTable implements
     private ToolManager toolManager;
     @Inject
     private ProjectManager projectManager;
-    
+
     private final ProjectContext projectContext;
 
     public Outline() {
@@ -191,7 +197,7 @@ public class Outline extends VisTable implements
                     }
 
                     // update tree
-                    buildTree(projectContext.currScene.sceneGraph);
+                    buildTree(sceneGraph);
                 }
             }
         });
@@ -252,7 +258,8 @@ public class Outline extends VisTable implements
     }
 
     /**
-     * Building tree from game objects in sceneGraph
+     * Building tree from game objects in sceneGraph, clearing previous
+     * sceneGraph
      *
      * @param sceneGraph
      */
@@ -321,7 +328,6 @@ public class Outline extends VisTable implements
 //            }
 //        }
 //    }
-
     @Override
     public void onGameObjectSelected(GameObjectSelectedEvent gameObjectSelectedEvent) {
         Tree.Node node = tree.findNode(gameObjectSelectedEvent.getGameObject());
@@ -344,7 +350,6 @@ public class Outline extends VisTable implements
             add(name).expand().fill();
             name.setText(go.name + " [" + go.id + "]");
         }
-
     }
 
     /**
@@ -355,6 +360,7 @@ public class Outline extends VisTable implements
         private MenuItem addEmpty;
         private MenuItem addTerrain;
         private MenuItem duplicate;
+        private MenuItem rename;
         private MenuItem delete;
 
         private GameObject selectedGO;
@@ -365,6 +371,7 @@ public class Outline extends VisTable implements
             addEmpty = new MenuItem("Add Empty");
             addTerrain = new MenuItem("Add terrain");
             duplicate = new MenuItem("Duplicate");
+            rename = new MenuItem("Rename");
             delete = new MenuItem("Delete");
 
             // add empty
@@ -398,6 +405,7 @@ public class Outline extends VisTable implements
                 @Override
                 public void clicked(InputEvent event, float x, float y) {
                     //To-DO: Terrain config popup: set width and height values, maybe heightmap import options
+                    Log.traceTag(TAG, "Add terrain game object in root node.");
                     Terrain terrain = TerrainUtils.createTerrain(projectContext.obtainID(), "Terrain", 1200, 1200, 180);
                     projectContext.terrains.add(terrain);
                     //projectContext.currScene.terrainGroup.add(terrain);
@@ -412,6 +420,12 @@ public class Outline extends VisTable implements
                 }
             });
 
+            rename.addListener(new ClickListener() {
+                @Override
+                public void clicked(InputEvent event, float x, float y) {
+                    showRenameDialog();
+                }
+            });
             // duplicate node, (How to solve copy/clone of game objects?)
 //            duplicate.addListener(new ClickListener() {
 //                @Override
@@ -421,12 +435,12 @@ public class Outline extends VisTable implements
 //                    Mundus.postEvent(new SceneGraphChangedEvent());
 //                }
 //            });
-
             // delete game object
             delete.addListener(new ClickListener() {
                 @Override
                 public void clicked(InputEvent event, float x, float y) {
                     if (selectedGO != null) {
+                        Log.traceTag(TAG, "Remove game object [{}].", selectedGO);
                         removeGo(selectedGO);
                         Mundus.postEvent(new SceneGraphChangedEvent());
                     }
@@ -435,13 +449,56 @@ public class Outline extends VisTable implements
 
             addItem(addEmpty);
             addItem(addTerrain);
-            addItem(duplicate);
+            addItem(rename);
+            //addItem(duplicate);
             addItem(delete);
+
         }
 
+        /**
+         * Right click event opens menu and enables more options if selected
+         * game object is active.
+         *
+         * @param go
+         * @param x
+         * @param y
+         */
         public void show(GameObject go, float x, float y) {
             selectedGO = go;
             showMenu(Ui.getInstance(), x, y);
+
+            //check if game oject is selected
+            if (selectedGO != null) {
+                //Activate menu options for selected game objects
+                rename.setDisabled(false);
+                //duplicate.setDisabled(false);
+                delete.setDisabled(false);
+            } else {
+                //disable MenuItems which only work with selected Item
+                rename.setDisabled(true);
+                //duplicate.setDisabled(true);
+                delete.setDisabled(true);
+            }
+        }
+
+        public void showRenameDialog() {
+            final Tree.Node node = tree.findNode(selectedGO);
+            final GameObject go = (GameObject) node.getObject();
+
+            InputDialog renameDialog = Dialogs.showInputDialog(Ui.getInstance(), "Rename", "", new InputDialogAdapter() {
+                @Override
+                public void finished(String input) {
+                    Log.traceTag(TAG, "Rename game object [{}] to [{}].", go, input);
+                    //update name
+                    go.name = input;
+
+                    Mundus.postEvent(new SceneGraphChangedEvent());
+                }
+            });
+            //set position of dialog to menuItem position
+            float nodePosX = node.getActor().getX();
+            float nodePosY = node.getActor().getY();
+            renameDialog.setPosition(nodePosX, nodePosY);
         }
 
     }

--- a/libgdx-runtime/src/com/mbrlabs/mundus/runtime/libgdx/ModelComponent.java
+++ b/libgdx-runtime/src/com/mbrlabs/mundus/runtime/libgdx/ModelComponent.java
@@ -20,6 +20,7 @@ import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.graphics.g3d.Shader;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.commons.scene3d.components.AbstractComponent;
+import com.mbrlabs.mundus.commons.scene3d.components.Component;
 
 /**
  *
@@ -53,6 +54,14 @@ public class ModelComponent extends AbstractComponent {
     @Override
     public void update(float delta) {
 
+    }
+
+    @Override
+    public Component clone(GameObject go) {
+        ModelComponent mc = new ModelComponent(go);
+        mc.shader = this.shader;
+        mc.modelInstance = this.modelInstance;
+        return mc;
     }
 
 }

--- a/libgdx-runtime/src/com/mbrlabs/mundus/runtime/libgdx/TerrainComponent.java
+++ b/libgdx-runtime/src/com/mbrlabs/mundus/runtime/libgdx/TerrainComponent.java
@@ -63,4 +63,10 @@ public class TerrainComponent extends AbstractComponent {
 
     }
 
+    @Override
+    public Component clone(GameObject go) {
+        throw new UnsupportedOperationException("Terrain can not be cloned.");
+    }
+
+
 }


### PR DESCRIPTION
- added duplicate function 
- terrain can not be duplicated
- fix: When outline menu items are set disabled they where still clickable
- fix: rename problem with duplication
- added deepCopy() to Component Interface
- testet duplicate with rename, drag and drop and translation of nodes