### PR TITLE
fix for parenting in outline, positions update 

### DIFF
--- a/editor/CHANGES
+++ b/editor/CHANGES
@@ -11,6 +11,7 @@
 - Implemented game object renaming in the outline
 - Implemented duplicate game object (deep copy), terrain can not be duplicated
 - Implemented delete game object undo/redo command
+- Fixed parenting in outline. Now local position is correctly calculated
 
 [0.0.8] ~ 23/06/2016
 - Updated libGDX to 1.9.3

--- a/editor/src/main/com/mbrlabs/mundus/tools/TranslateTool.java
+++ b/editor/src/main/com/mbrlabs/mundus/tools/TranslateTool.java
@@ -197,10 +197,6 @@ public class TranslateTool extends TransformTool {
 //            }
 
             go.translate(vec);
-            // translate child go
-//            if(go.getChildren() != null) {
-//                translateChildren(go.getChildren(), vec);
-//            }
 
             if(modified) {
                 gameObjectModifiedEvent.setGameObject(projectManager.current().currScene.currentSelection);
@@ -208,14 +204,6 @@ public class TranslateTool extends TransformTool {
             }
 
             lastPos.set(rayEnd);
-        }
-    }
-    
-    private void translateChildren(Array<GameObject> children, Vector3 translateValue) {
-        for(GameObject child : children) {
-            child.translate(translateValue);
-            if(child.getChildren() != null)
-                translateChildren(child.getChildren(), translateValue);
         }
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/tools/TranslateTool.java
+++ b/editor/src/main/com/mbrlabs/mundus/tools/TranslateTool.java
@@ -24,10 +24,11 @@ import com.badlogic.gdx.graphics.VertexAttributes;
 import com.badlogic.gdx.graphics.g3d.*;
 import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
 import com.badlogic.gdx.graphics.g3d.utils.ModelBuilder;
+import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.math.Quaternion;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.math.collision.Ray;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
-import com.badlogic.gdx.utils.Array;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.core.Mundus;
 import com.mbrlabs.mundus.core.project.ProjectManager;
@@ -41,8 +42,8 @@ import com.mbrlabs.mundus.utils.Fa;
 import org.lwjgl.opengl.GL11;
 
 /**
- * @author Marcus Brummer, codenigma
- * @version 10-09-2015
+ * @author Marcus Brummer
+ * @version 26-12-2015
  */
 public class TranslateTool extends TransformTool {
 

--- a/editor/src/main/com/mbrlabs/mundus/tools/TranslateTool.java
+++ b/editor/src/main/com/mbrlabs/mundus/tools/TranslateTool.java
@@ -24,11 +24,10 @@ import com.badlogic.gdx.graphics.VertexAttributes;
 import com.badlogic.gdx.graphics.g3d.*;
 import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
 import com.badlogic.gdx.graphics.g3d.utils.ModelBuilder;
-import com.badlogic.gdx.math.Matrix4;
-import com.badlogic.gdx.math.Quaternion;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.math.collision.Ray;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
+import com.badlogic.gdx.utils.Array;
 import com.mbrlabs.mundus.commons.scene3d.GameObject;
 import com.mbrlabs.mundus.core.Mundus;
 import com.mbrlabs.mundus.core.project.ProjectManager;
@@ -42,8 +41,8 @@ import com.mbrlabs.mundus.utils.Fa;
 import org.lwjgl.opengl.GL11;
 
 /**
- * @author Marcus Brummer
- * @version 26-12-2015
+ * @author Marcus Brummer, codenigma
+ * @version 10-09-2015
  */
 public class TranslateTool extends TransformTool {
 
@@ -198,6 +197,10 @@ public class TranslateTool extends TransformTool {
 //            }
 
             go.translate(vec);
+            // translate child go
+//            if(go.getChildren() != null) {
+//                translateChildren(go.getChildren(), vec);
+//            }
 
             if(modified) {
                 gameObjectModifiedEvent.setGameObject(projectManager.current().currScene.currentSelection);
@@ -205,6 +208,14 @@ public class TranslateTool extends TransformTool {
             }
 
             lastPos.set(rayEnd);
+        }
+    }
+    
+    private void translateChildren(Array<GameObject> children, Vector3 translateValue) {
+        for(GameObject child : children) {
+            child.translate(translateValue);
+            if(child.getChildren() != null)
+                translateChildren(child.getChildren(), translateValue);
         }
     }
 

--- a/editor/src/main/com/mbrlabs/mundus/ui/modules/Outline.java
+++ b/editor/src/main/com/mbrlabs/mundus/ui/modules/Outline.java
@@ -196,7 +196,7 @@ public class Outline extends VisTable implements
                     // add to new parent
                     if (newParent == null) {
                         // recalculate position for root layer
-                        Vector3 newPos = new Vector3();
+                        Vector3 newPos;
                         Vector3 draggedPos = new Vector3();
                         draggedGo.getPosition(draggedPos);
                         //if moved from old parent


### PR DESCRIPTION
- When moving children in tree, position is now calculated correctly (node will not translate in wrong direction)
- translation/rotation of parent is working correctly