### PR TITLE
Fix of the  https://github.com/mbrlabs/Mundus/issues/26

### DIFF
--- a/editor/src/main/com/mbrlabs/mundus/tools/ToolManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/tools/ToolManager.java
@@ -93,7 +93,7 @@ public class ToolManager extends InputAdapter implements Disposable {
     }
 
     public void setDefaultTool() {
-        if (activeTool == null)
+        if (activeTool == null || activeTool == modelPlacementTool)
             activateTool(translateTool);
         else
             activeTool.reset();
@@ -136,7 +136,6 @@ public class ToolManager extends InputAdapter implements Disposable {
         translateTool.dispose();
         modelPlacementTool.dispose();
         selectionTool.dispose();
-        translateTool.dispose();
         rotateTool.dispose();
         scaleTool.dispose();
     }

--- a/editor/src/main/com/mbrlabs/mundus/tools/ToolManager.java
+++ b/editor/src/main/com/mbrlabs/mundus/tools/ToolManager.java
@@ -93,8 +93,11 @@ public class ToolManager extends InputAdapter implements Disposable {
     }
 
     public void setDefaultTool() {
-        deactivateTool();
-        activateTool(translateTool);
+        if (activeTool == null)
+            activateTool(translateTool);
+        else
+            activeTool.reset();
+
     }
 
     public void render() {
@@ -131,6 +134,11 @@ public class ToolManager extends InputAdapter implements Disposable {
             brush.dispose();
         }
         translateTool.dispose();
+        modelPlacementTool.dispose();
+        selectionTool.dispose();
+        translateTool.dispose();
+        rotateTool.dispose();
+        scaleTool.dispose();
     }
 
 }


### PR DESCRIPTION
Also, dispose() method of the toolManager fixed -- it was disposing only translateTool( leaving resources allocated to another tools untouched).